### PR TITLE
PIA-2698-fix-ios-dll

### DIFF
--- a/ExampleiOSApp/ExampleiOSApp.csproj
+++ b/ExampleiOSApp/ExampleiOSApp.csproj
@@ -78,7 +78,7 @@
         </Reference>
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
+      <PackageReference Include="Xamarin.Essentials" Version="1.7.3" />
     </ItemGroup>
     <ItemGroup>
         <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">

--- a/ExampleiOSApp/ExampleiOSApp.csproj
+++ b/ExampleiOSApp/ExampleiOSApp.csproj
@@ -28,6 +28,7 @@
         <MtouchDebug>true</MtouchDebug>
         <CodesignKey>iPhone Developer</CodesignKey>
         <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+        <CodesignProvision>Automatic</CodesignProvision>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
         <DebugType>none</DebugType>
@@ -52,6 +53,7 @@
         <CodesignKey>iPhone Developer</CodesignKey>
         <MtouchDebug>true</MtouchDebug>
         <MtouchLink>SdkOnly</MtouchLink>
+        <CodesignProvision>Automatic</CodesignProvision>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
         <DebugType>none</DebugType>

--- a/ExampleiOSApp/Info.plist
+++ b/ExampleiOSApp/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>ExampleiOSApp</string>
 	<key>CFBundleIdentifier</key>
-	<string>net.gini.xamarin.forms.GVL-Example2</string>
+	<string>net.gini.xamarin.forms.GVL-Example</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/GiniBank.iOS.Proxy/GiniBankProxy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GiniBank.iOS.Proxy/GiniBankProxy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gini/bank-api-library-ios.git",
       "state" : {
-        "revision" : "aa7fd4d3b3d3a37db4cc77a96a263b4c6c1215a8",
-        "version" : "1.1.1"
+        "revision" : "982451b0227b275c9f4a9b5a192e21c3259e477e",
+        "version" : "1.3.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gini/bank-api-library-pinning-ios.git",
       "state" : {
-        "revision" : "923aa785c6623c31574125262fd329d1a0954b01",
-        "version" : "1.1.1"
+        "revision" : "9ad10ded75d31c6b23e4ab8049b5808e4930e8be",
+        "version" : "1.3.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gini/bank-sdk-ios.git",
       "state" : {
-        "revision" : "9f47f9264ff457c0066cd572279228f6581556c9",
-        "version" : "1.5.0"
+        "revision" : "3b9a538bbe2bbb6432693f79b286cd55978c5e12",
+        "version" : "1.10.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gini/bank-sdk-pinning-ios",
       "state" : {
-        "revision" : "002c19532ebd455617076c5de5cd6e7a2524de2f",
-        "version" : "1.5.0"
+        "revision" : "294421a623c6292bb4c5db660e4d2f595956da24",
+        "version" : "1.10.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gini/capture-sdk-ios.git",
       "state" : {
-        "revision" : "977a7a6679edce1a5d9f0516bb42d8ff42e56656",
-        "version" : "1.5.0"
+        "revision" : "bf0d8011e5781298f6c0551e18d97e50b06d85cf",
+        "version" : "1.9.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gini/capture-sdk-pinning-ios.git",
       "state" : {
-        "revision" : "3025bff30d0fa54beb72c69015231eb4eaedd77b",
-        "version" : "1.5.0"
+        "revision" : "b3e09de09366ec4c61da3a5d9878c0f73178d93a",
+        "version" : "1.9.0"
       }
     },
     {

--- a/GiniBank.iOS.Proxy/build/README.txt
+++ b/GiniBank.iOS.Proxy/build/README.txt
@@ -1,5 +1,0 @@
-# Open GiniBankProxy.xcodeproj in XCode and build in 'iOS device' and 'ios simulator' modes(release)
-# Go to /Users/{username}/Library/Developer/Xcode/DerivedData(Xcode->Preferences->Locations-Derived Data)
-# Copy folders Release-iphoneos and Release-iphonesimulator 
-from GiniBankProxy...../Build/Products/to GiniBank.iOS.Proxy/build folder
-# run 'bash build.sh'

--- a/GiniBank.iOS/GiniBank.iOS.csproj
+++ b/GiniBank.iOS/GiniBank.iOS.csproj
@@ -51,5 +51,10 @@
       <SmartLink>False</SmartLink>
     </NativeReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Essentials">
+      <Version>1.7.3</Version>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets" />
 </Project>

--- a/README.md
+++ b/README.md
@@ -322,6 +322,5 @@ The buttons currently available for customization are:
 1. Open `GiniBankProxy.xcodeproj` in XCode and build in 'iOS device' and 'iOS simulator' modes for release.
 2. Go to `/Users/{username}/Library/Developer/Xcode/DerivedData` (you can also go to Xcode->Preferences->Locations-Derived Data to find the folder).
 3. Copy the `Release-iphoneos` and `Release-iphonesimulator` folders from `.../DerivedData/GiniBankProxy(...)/Build/Products/` to `GiniBank.iOS.Proxy/build/`.
-4. Run `./build-ios.sh`.  
-   If it fails with `System.BadImageFormatException: Invalid Image` error then download and install Xamarin.iOS 15.2.0.1 from here: https://aka.ms/xvs/pkg/macios/15.2.0.1
+4. Run `./build-ios.sh`.
 5. The new `GiniBank.iOS.dll` will be generated and copied to the `ExampleiOSApp` folder.

--- a/build-ios.sh
+++ b/build-ios.sh
@@ -20,8 +20,8 @@ cp -R build/Release-iphoneos build/Release-fat
 cp -R build/Release-iphonesimulator/GiniBankProxy.framework/Modules/GiniBankProxy.swiftmodule build/Release-fat/GiniBankProxy.framework/Modules
 
 # copy bundle res(swift packages issue)
-cp -R build/Release-iphonesimulator/GiniBankSDK_GiniBankSDK.bundle build/Release-fat/GiniBankProxy.framework
-cp -R build/Release-iphonesimulator/GiniCaptureSDK_GiniCaptureSDK.bundle build/Release-fat/GiniBankProxy.framework
+cp -R build/Release-iphoneos/GiniBankSDK_GiniBankSDK.bundle build/Release-fat/GiniBankProxy.framework
+cp -R build/Release-iphoneos/GiniCaptureSDK_GiniCaptureSDK.bundle build/Release-fat/GiniBankProxy.framework
 
 # Create fat library
 lipo -create build/Release-iphoneos/GiniBankProxy.framework/GiniBankProxy build/Release-iphonesimulator/GiniBankProxy.framework/GiniBankProxy -output build/Release-fat/GiniBankProxy.framework/GiniBankProxy

--- a/build-ios.sh
+++ b/build-ios.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
+# 
+# Builds the GiniBank.iOS.dll.
+#
+# Check the README for required preconditions.
+#
 
-# Open GiniBankProxy.xcodeproj in XCode and build in 'iOS device' and 'ios simulator' modes(release)
-# Go to /Users/{username}/Library/Developer/Xcode/DerivedData(Xcode->Preferences->Locations-Derived Data)
-# Copy folders Release-iphoneos and Release-iphonesimulator 
-# from GiniBankProxy...../Build/Products/to GiniBank.iOS.Proxy/build folder
+# Uncomment for debugging (prints the executed commands)
+# set -x
 
 pushd GiniBank.iOS.Proxy
 
@@ -24,7 +27,6 @@ cp -R build/Release-iphonesimulator/GiniCaptureSDK_GiniCaptureSDK.bundle build/R
 lipo -create build/Release-iphoneos/GiniBankProxy.framework/GiniBankProxy build/Release-iphonesimulator/GiniBankProxy.framework/GiniBankProxy -output build/Release-fat/GiniBankProxy.framework/GiniBankProxy
 
 # Generate binding classes
-# If it fails with "System.BadImageFormatException: Invalid Image" error then download and install Xamarin.iOS 15.2.0.1 from here: https://aka.ms/xvs/pkg/macios/15.2.0.1
 sharpie bind --sdk=iphoneos --output="build/XamarinApiDef" --namespace="GiniBank.iOS"  --scope=build/Release-fat/GiniBankProxy.framework/Headers build/Release-fat/GiniBankProxy.framework/Headers/GiniBankProxy-Swift.h -c -F build/Release-fat
 # TODO: fix 3 erros on missed Foundations(No extensions and onboardingPages)
 
@@ -37,6 +39,10 @@ mv build/XamarinApiDef/APIDefinitions.cs_new build/XamarinApiDef/APIDefinitions.
 # Fix nint to long issue
 sed 's/nint/long/g' build/XamarinApiDef/StructsAndEnums.cs > build/XamarinApiDef/StructsAndEnums.cs_new
 mv build/XamarinApiDef/StructsAndEnums.cs_new build/XamarinApiDef/StructsAndEnums.cs
+
+# Revert .NET 6 NativeHandle to previous IntPtr type so that it works with the bindings project (https://github.com/xamarin/xamarin-macios/issues/13087)
+sed 's/NativeHandle/IntPtr/g' build/XamarinApiDef/APIDefinitions.cs > build/XamarinApiDef/APIDefinitions.cs_new
+mv build/XamarinApiDef/APIDefinitions.cs_new build/XamarinApiDef/APIDefinitions.cs
 
 # Copy to Bindings
 cp build/XamarinApiDef/* ../GiniBank.iOS


### PR DESCRIPTION
* Fixes dll build script for latest Visual Studio code and .NET 6.
* Adds iphoneos bundles instead of the iphonesimulator ones.

There was fortunately no need to create a device only dll. It wasn't working and that led me to the real cause which was that we used iphonesimulator bundles when creating the dll...

If you want to build locally:
* Update Visual Studio to latest version: https://visualstudio.microsoft.com/vs/mac/
* Update sharpie to latest version: https://docs.microsoft.com/en-us/xamarin/cross-platform/macios/binding/objective-sharpie/get-started